### PR TITLE
Made estimate_size more resilient to missing or malformed CONTENT_LENGTH header

### DIFF
--- a/vsd/src/playlist.rs
+++ b/vsd/src/playlist.rs
@@ -700,11 +700,8 @@ impl MediaPlaylist {
             let content_length = response
                 .headers()
                 .get(header::CONTENT_LENGTH)
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .parse::<usize>()
-                .unwrap();
+                .map(|h| h.to_str().unwrap_or("0").parse::<usize>().unwrap_or(0usize))
+                .unwrap_or(0usize);
 
             if total_segments > 1 {
                 return Ok(total_segments * content_length);


### PR DESCRIPTION
I was batch downloading a bunch of videos and some of the CDN servers did not think it important to send a CONTENT_LENGTH headers which made the process crash after fetching half of the video. 127 of 188 videos had that issue for some reason. 

I didn't have time  to properly refactor `estimate_size` to return an error in case the header is missing and to make `download_streams` handle the fallback case properly if there is no estimate available so consider this more of a hotfix.

Thanks for making this cool tool btw. I am enjoying it.
Cheers!